### PR TITLE
Remove now unneeded feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! A rust-based version control system
 
 #![feature(stmt_expr_attributes)]
-#![feature(const_slice_from_raw_parts_mut)]
 
 pub mod stack;


### PR DESCRIPTION
the feature `const_slice_from_raw_parts_mut` has been stable since 1.83.0-nightly and no longer requires an attribute to enable