### PR TITLE
Remove useless commands in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
 
-RUN rustup toolchain install nightly --profile minimal -c clippy,rustfmt
 COPY --chown=vscode:vscode config.toml /home/vscode/.cargo/config.toml
 RUN cargo install bacon sccache cargo-expand

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,10 +5,7 @@
 		"vscode": {
 			"settings": {
 				"editor.formatOnSave": true,
-				"rust-analyzer.check.command": "clippy",
-				"rust-analyzer.rustfmt.extraArgs": [
-					"+nightly"
-				]
+				"rust-analyzer.check.command": "clippy"
 			}
 		}
 	}


### PR DESCRIPTION
It is not useful to install rust nightly because of the [rust-toolchain.toml](https://github.com/solipr/solipr/blob/main/rust-toolchain.toml) file.