### PR TITLE
Allow clippy::multiple_crate_versions lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ non_ascii_idents = "warn"
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
+multiple_crate_versions = "allow"
 module_name_repetitions = "allow"
 absolute_paths = "warn"
 allow_attributes = "warn"

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -248,7 +248,7 @@ pub trait Repository<'manager> {
     ///
     /// An error will be returned if there was an error while doing the
     /// operation.
-    fn apply(&self, change: Change) -> Result<ChangeHash, Self::Error>;
+    fn apply(&mut self, change: Change) -> Result<ChangeHash, Self::Error>;
 
     /// Unapplies the change with the given [`ChangeHash`].
     ///
@@ -259,7 +259,7 @@ pub trait Repository<'manager> {
     ///
     /// An error will be returned if there was an error while doing the
     /// operation.
-    fn unapply(&self, change_hash: ChangeHash) -> Result<(), Self::Error>;
+    fn unapply(&mut self, change_hash: ChangeHash) -> Result<(), Self::Error>;
 
     /// Commit the changes made to the repository.
     ///


### PR DESCRIPTION
Because this can be caused purely by the dependencies themselves, it’s not always possible to fix this issue.