### PR TITLE
Make FIRST and LAST line parent/child always the same

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -248,6 +248,9 @@ pub trait Repository<'manager> {
         file_id: FileId,
         line_id: LineId,
     ) -> Result<HashSet<LineId>, Self::Error> {
+        if line_id == LineId::FIRST {
+            return Ok(HashSet::new());
+        }
         let heads = self.heads(SingleId::LineParent(file_id, line_id))?;
         let mut result = HashSet::with_capacity(heads.len());
         for head in heads {
@@ -275,6 +278,9 @@ pub trait Repository<'manager> {
     /// An error will be returned if there was an error while doing the
     /// operation.
     fn line_child(&self, file_id: FileId, line_id: LineId) -> Result<HashSet<LineId>, Self::Error> {
+        if line_id == LineId::LAST {
+            return Ok(HashSet::new());
+        }
         let heads = self.heads(SingleId::LineChild(file_id, line_id))?;
         let mut result = HashSet::with_capacity(heads.len());
         for head in heads {


### PR DESCRIPTION
This will make modification to the parent of the first line and to the child of the last line impossible.