### PR TITLE
Remove FIRST and LAST line

### DIFF
--- a/crates/core/src/change.rs
+++ b/crates/core/src/change.rs
@@ -82,23 +82,11 @@ impl Deref for FileId {
 pub struct LineId(Uuid);
 
 impl LineId {
-    /// The identifier of the first line in a file.
-    ///
-    /// This is line is not a real line, it is used to indicate the beginning of
-    /// the file.
-    pub const FIRST: Self = Self(Uuid::nil());
-
-    /// The identifier of the last line in a file.
-    ///
-    /// This is line is not a real line, it is used to indicate the end of the
-    /// file.
-    pub const LAST: Self = Self(Uuid::max());
-
     /// The identifier of an unknown line in a file.
     ///
     /// This is the identifier used for each line read from a file before using
     /// the diff algorithm to detect changes.
-    pub const UNKNOWN: Self = Self(Uuid::from_bytes([1; 16]));
+    pub const UNKNOWN: Self = Self(Uuid::nil());
 
     /// Combine multiple lines into a unique identifier.
     pub fn combine(lines: impl IntoIterator<Item = Self>) -> Uuid {

--- a/crates/core/src/repository/head.rs
+++ b/crates/core/src/repository/head.rs
@@ -85,9 +85,6 @@ pub trait HeadExt<'manager>: Repository<'manager> {
         file_id: FileId,
         line_id: LineId,
     ) -> Result<HashSet<LineId>, Self::Error> {
-        if line_id == LineId::FIRST {
-            return Ok(HashSet::new());
-        }
         let heads = self.heads(SingleId::LineParent(file_id, line_id))?;
         let mut result = HashSet::with_capacity(heads.len());
         for head in heads {
@@ -98,9 +95,6 @@ pub trait HeadExt<'manager>: Repository<'manager> {
             {
                 result.insert(parent);
             }
-        }
-        if result.is_empty() {
-            result.insert(LineId::FIRST);
         }
         Ok(result)
     }
@@ -115,9 +109,6 @@ pub trait HeadExt<'manager>: Repository<'manager> {
     /// An error will be returned if there was an error while doing the
     /// operation.
     fn line_child(&self, file_id: FileId, line_id: LineId) -> Result<HashSet<LineId>, Self::Error> {
-        if line_id == LineId::LAST {
-            return Ok(HashSet::new());
-        }
         let heads = self.heads(SingleId::LineChild(file_id, line_id))?;
         let mut result = HashSet::with_capacity(heads.len());
         for head in heads {
@@ -128,9 +119,6 @@ pub trait HeadExt<'manager>: Repository<'manager> {
             {
                 result.insert(child);
             }
-        }
-        if result.is_empty() {
-            result.insert(LineId::LAST);
         }
         Ok(result)
     }


### PR DESCRIPTION
In the final algorithm, all the nodes of the graph are visited, so finding the first and last node can only be done by checking parents. And doing this will reduce a little the number of changes applied to the repository.